### PR TITLE
Tweak development dependencies

### DIFF
--- a/fluent-plugin-postgres.gemspec
+++ b/fluent-plugin-postgres.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'pg'
 
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit', '~> 3.2.0'
 end


### PR DESCRIPTION
This is required for Ruby 2.2 or later.