### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-postgres.gemspec
+++ b/fluent-plugin-postgres.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_dependency 'fluentd'
+  s.add_dependency 'fluentd', ['>= 0.14.15', '< 2']
   s.add_dependency 'pg'
 
   s.add_development_dependency 'rake'

--- a/lib/fluent/plugin/out_postgres.rb
+++ b/lib/fluent/plugin/out_postgres.rb
@@ -21,10 +21,6 @@ class Fluent::Plugin::PostgresOutput < Fluent::Plugin::Output
 
   attr_accessor :handler
 
-  def initialize
-    super
-  end
-
   # We don't currently support mysql's analogous json format
   def configure(conf)
     compat_parameters_convert(conf, :inject)

--- a/lib/fluent/plugin/out_postgres.rb
+++ b/lib/fluent/plugin/out_postgres.rb
@@ -1,4 +1,5 @@
 require 'fluent/plugin/output'
+require 'pg'
 
 class Fluent::Plugin::PostgresOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('postgres', self)
@@ -22,7 +23,6 @@ class Fluent::Plugin::PostgresOutput < Fluent::Plugin::Output
 
   def initialize
     super
-    require 'pg'
   end
 
   # We don't currently support mysql's analogous json format

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|
@@ -25,4 +27,5 @@ end
 require 'fluent/plugin/out_postgres'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end


### PR DESCRIPTION
Please take a look after #4 is merged.

---

I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.