### PR TITLE
Permit spaces around comma in key_names

### DIFF
--- a/lib/fluent/plugin/out_postgres.rb
+++ b/lib/fluent/plugin/out_postgres.rb
@@ -31,7 +31,7 @@ class Fluent::PostgresOutput < Fluent::BufferedOutput
     if @format == 'json'
       @format_proc = Proc.new{|tag, time, record| record.to_json}
     else
-      @key_names = @key_names.split(',')
+      @key_names = @key_names.split(/\s*,\s*/)
       @format_proc = Proc.new{|tag, time, record| @key_names.map{|k| record[k]}}
     end
 

--- a/test/plugin/test_out_postgres.rb
+++ b/test/plugin/test_out_postgres.rb
@@ -57,6 +57,19 @@ key_names field1,field2,field3
     }
   end
 
+  def test_key_names_with_spaces
+    d = create_driver %[
+host database.local
+database foo
+username bar
+password mogera
+table baz
+key_names time, tag, field1, field2, field3, field4
+sql INSERT INTO baz (coltime,coltag,col1,col2,col3,col4) VALUES (?,?,?,?,?,?)
+    ]
+    assert_equal ["time", "tag", "field1", "field2", "field3", "field4"], d.instance.key_names
+  end
+
   def test_time_and_tag_key
     d = create_driver %[
 host database.local


### PR DESCRIPTION
Origninally, it is repoeted in https://obel.hatenablog.jp/entry/20170127/1485482888 (Japanese)